### PR TITLE
DistroKid Videos API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ As of now, the wrapper supports the following features:
 
 - **Releases Getters**: Retrieve information about music releases, including title, artist, release date, and more.
 - **Tracks Getters**: Fetch details and statistics for individual tracks, such as duration, ISRC, play counts, and other relevant data.
+- **Video Getters**: Fetch information about music videos, including title, artist, views, description, thumbnails and more.
 
 ## Planned Features
 
@@ -46,6 +47,27 @@ func main() {
   }
 
   fmt.Printf("Found %d releases\n", len(releases))
+}
+```
+
+Using the videos API doesn't require a token:
+```go
+package main
+
+import (
+  "fmt"
+
+  "github.com/szerookii/distrogo"
+)
+
+func main() {
+  videos, err := distrogo.GetVideos([]string{"Rc92Mqy6SWr", "mv-K0ye9T6Xv", "dv-5yW2dTd8N"})
+
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("Found %d videos\n", len(videos))
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/szerookii/distrogo
 
 go 1.16
+
+require (
+	github.com/gocolly/colly v1.2.0
+)

--- a/videos.go
+++ b/videos.go
@@ -1,7 +1,6 @@
 package distrogo
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -34,7 +33,7 @@ type Video struct {
 }
 
 func GetVideo(id string) (Video, error) {
-	url := fmt.Sprintf("https://distrokid.com/videos/watch/%s", id)
+	url := "https://distrokid.com/videos/watch/" + id
 	collector := colly.NewCollector()
 
 	var video Video

--- a/videos.go
+++ b/videos.go
@@ -165,9 +165,9 @@ func GetVideo(id string) (Video, error) {
 		return video, errors.New("Video unavailable (redirected).")
 	}
 
-	if video.Type == VIDEO_TYPE_MINIVIDEO && len(video.Artist) == 0 {
-		// If we couldn't get the artist name for a mini-video from recommended videos,
-		// closest thing we can get to an artist name is the uploader's DistroKid username.
+	if len(video.Artist) == 0 {
+		// If we couldn't get the artist name,
+		// closest thing we can get to one is the uploader's DistroKid username.
 		video.Artist = video.Uploader
 	}
 

--- a/videos.go
+++ b/videos.go
@@ -39,6 +39,7 @@ type Video struct {
 	Thumbnail          string
 	AnimatedThumbnail  string
 	SourceURL          string
+	Recommended        []string
 }
 
 func GetVideo(id string) (Video, error) {
@@ -79,11 +80,14 @@ func GetVideo(id string) (Video, error) {
 			}
 		}
 	})
-	collector.OnHTML("div.relatedVideoCaption", func(el *colly.HTMLElement) {
-		if video.Type == VIDEO_TYPE_MINIVIDEO && len(video.Artist) == 0 {
-			// Get mini-video artist name from recommended videos.
-			video.Artist = el.ChildText("div[style*=\"font-weight: 700\"]")
-		}
+	collector.OnHTML("div.relatedVideosContainer", func(el *colly.HTMLElement) {
+		el.ForEach("a", func(i int, linkEl *colly.HTMLElement) {
+			if video.Type == VIDEO_TYPE_MINIVIDEO && len(video.Artist) == 0 {
+				// Get mini-video artist name from recommended videos.
+				video.Artist = linkEl.ChildText("div[style*=\"font-weight: 700\"]")
+			}
+			video.Recommended = append(video.Recommended, strings.TrimPrefix(linkEl.Attr("href"), "/videos/watch/"))
+		})
 	})
 	collector.OnHTML("div.vMemberSince", func(el *colly.HTMLElement) {
 		el.ForEach("div", func(i int, infoEl *colly.HTMLElement) {

--- a/videos.go
+++ b/videos.go
@@ -1,0 +1,141 @@
+package distrogo
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gocolly/colly"
+)
+
+const (
+	VIDEO_TYPE_VIZY = iota
+	VIDEO_TYPE_MINIVIDEO = iota
+	VIDEO_TYPE_DISTROVID = iota
+)
+
+type Video struct {
+	ID                 string
+	Type               int
+	Stores             []string
+	Artist             string
+	Uploader           string
+	Title              string
+	Description        string
+	UploadDate         time.Time
+	ReleaseDate        time.Time
+	UploadDateString   string
+	ReleaseDateString  string
+	DistroKidViews     int
+	Thumbnail          string
+	AnimatedThumbnail  string
+	SourceURL          string
+}
+
+func GetVideo(id string) (Video, error) {
+	url := fmt.Sprintf("https://distrokid.com/videos/watch/%s", id)
+	collector := colly.NewCollector()
+
+	var video Video
+	var err error
+
+	video.ID = id
+	if strings.HasPrefix(id, "mv-") {
+		video.Type = VIDEO_TYPE_MINIVIDEO
+	} else if strings.HasPrefix(id, "dv-") {
+		video.Type = VIDEO_TYPE_DISTROVID
+	} else {
+		video.Type = VIDEO_TYPE_VIZY
+	}
+
+	collector.OnError(func(r *colly.Response, e error) {
+		err = e
+	})
+
+	collector.OnHTML("div.videoMetadataContainer", func(el *colly.HTMLElement) {
+		video.Title = strings.TrimSpace(el.DOM.Find("div[style*=\"line-height: 1.5\"]").Nodes[0].FirstChild.Data)
+		video.Uploader = el.ChildText("div.vUsername")
+
+		if video.Type == VIDEO_TYPE_DISTROVID {
+			video.Artist = el.ChildText("div[style*=\"font-weight: 400\"]")
+		} else if video.Type == VIDEO_TYPE_MINIVIDEO {
+			video.Title = strings.TrimSuffix(video.Title, " Mini Video") // Trim constant "Mini Video" text from title.
+			// We will try getting the artist's name from recommended videos first.
+		} else {
+			// For Vizy videos, the title is in an "Artist - Title" format.
+			splitTitle := strings.Split(video.Title, " - ")
+			if len(splitTitle) > 1 {
+				video.Artist = splitTitle[0]
+				video.Title = splitTitle[1]
+			}
+		}
+	})
+	collector.OnHTML("div.relatedVideoCaption", func(el *colly.HTMLElement) {
+		if video.Type == VIDEO_TYPE_MINIVIDEO && len(video.Artist) == 0 {
+			// Get mini-video artist name from recommended videos.
+			video.Artist = el.ChildText("div[style*=\"font-weight: 700\"]")
+		}
+	})
+	collector.OnHTML("div.vMemberSince", func(el *colly.HTMLElement) {
+		el.ForEach("div", func(i int, infoEl *colly.HTMLElement) {
+			if (i == 1) {
+				views, convErr := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(infoEl.Text), " views"))
+				err = convErr
+				video.DistroKidViews = views
+			} else if (i == 3) {
+				video.UploadDateString = strings.TrimPrefix(strings.TrimSpace(infoEl.Text), "since ")
+
+				uploadDate, parseErr := time.Parse("Jan _2, 2006", video.UploadDateString)
+				err = parseErr
+				video.UploadDate = uploadDate
+			}
+        })
+	})
+	collector.OnHTML("div.vDescription", func(el *colly.HTMLElement) {
+		video.Description = el.ChildText("pre")
+	})
+	collector.OnHTML("div.vDspContent", func(el *colly.HTMLElement) {
+		el.ForEach("img.store-icon", func(i int, storeEl *colly.HTMLElement) {
+			video.Stores = append(video.Stores, storeEl.Attr("title"))
+		})
+	})
+	collector.OnHTML("div.dvMetadataSection", func(el *colly.HTMLElement) {
+		video.ReleaseDateString = strings.TrimPrefix(el.ChildText("div"), "Release date: ")
+
+		if (len(video.ReleaseDateString) > 0) {
+			releaseDate, parseErr := time.Parse("Jan _2, 2006", video.ReleaseDateString)
+			err = parseErr
+			video.ReleaseDate = releaseDate
+		}
+	})
+	collector.OnHTML("video#my-player", func(el *colly.HTMLElement) {
+		video.Thumbnail = el.Attr("poster")
+		video.AnimatedThumbnail = video.Thumbnail[:strings.LastIndex(video.Thumbnail, "/")] + "/animated.gif"
+	})
+	collector.OnHTML("source[type=\"application/x-mpegURL\"]", func(el *colly.HTMLElement) {
+		video.SourceURL = el.Attr("src")
+	})
+
+	collector.Visit(url)
+
+	if video.Type == VIDEO_TYPE_MINIVIDEO && len(video.Artist) == 0 {
+		// If we couldn't get the artist name for a mini-video from recommended videos,
+		// closest thing we can get to an artist name is the uploader's DistroKid username.
+		video.Artist = video.Uploader
+	}
+
+	return video, err
+}
+
+func GetVideos(ids []string) ([]Video, error) {
+	var videos []Video
+	for _, id := range ids {
+		video, err := GetVideo(id)
+		if err != nil {
+			return videos, err
+		}
+		videos = append(videos, video)
+	}
+	return videos, nil
+}

--- a/videos.go
+++ b/videos.go
@@ -49,7 +49,7 @@ func GetVideo(id string) (Video, error) {
 
 	var video Video
 	var err error
-	var redirected bool = false
+	var customErr error
 
 	video.ID = id
 	if strings.HasPrefix(id, "mv-") {
@@ -64,10 +64,16 @@ func GetVideo(id string) (Video, error) {
 		err = e
 	})
 	collector.RedirectHandler = func(r *http.Request, via []*http.Request) error {
-		redirected = true
+		customErr = errors.New("Video unavailable (redirected).")
 		return http.ErrUseLastResponse
 	}
 
+	collector.OnHTML("title", func(el *colly.HTMLElement) {
+		if (!strings.Contains(el.Text, " - ")) {
+			// No " - " in window title would indicate the video is unavailable.
+			customErr = errors.New("Video unavailable.")
+		}
+	})
 	collector.OnHTML("div.videoMetadataContainer", func(el *colly.HTMLElement) {
 		video.Title = strings.TrimSpace(el.DOM.Find("div[style*=\"line-height: 1.5\"]").Nodes[0].FirstChild.Data)
 		video.Uploader = el.ChildText("div.vUsername")
@@ -156,8 +162,8 @@ func GetVideo(id string) (Video, error) {
 
 	collector.Visit(url)
 
-	if redirected {
-		return video, errors.New("Video unavailable (redirected).")
+	if customErr != nil {
+		return video, customErr
 	}
 
 	if len(video.Artist) == 0 {

--- a/videos.go
+++ b/videos.go
@@ -17,7 +17,6 @@ const (
 )
 
 const (
-	VIDEO_STORE_NONE = iota
 	VIDEO_STORE_BOOMPLAY = iota
 	VIDEO_STORE_APPLEMUSIC = iota
 	VIDEO_STORE_TIDAL = iota
@@ -28,7 +27,7 @@ const (
 type Video struct {
 	ID                 string
 	Type               int
-	Stores             []int
+	Stores             [5]bool
 	Artist             string
 	Uploader           string
 	Title              string
@@ -116,26 +115,22 @@ func GetVideo(id string) (Video, error) {
 	})
 	collector.OnHTML("div.vDspContent", func(el *colly.HTMLElement) {
 		el.ForEach("img.store-icon:not(.hidden)", func(i int, storeEl *colly.HTMLElement) {
-			var store int = VIDEO_STORE_NONE
 			switch storeEl.Attr("id") {
 				case "dsp-87":
-					store = VIDEO_STORE_BOOMPLAY
+					video.Stores[VIDEO_STORE_BOOMPLAY] = true
 					break
 				case "dsp-41":
-					store = VIDEO_STORE_APPLEMUSIC
+					video.Stores[VIDEO_STORE_APPLEMUSIC] = true
 					break
 				case "dsp-42":
-					store = VIDEO_STORE_TIDAL
+					video.Stores[VIDEO_STORE_TIDAL] = true
 					break
 				case "dsp-79":
-					store = VIDEO_STORE_TIKTOKMUSIC
+					video.Stores[VIDEO_STORE_TIKTOKMUSIC] = true
 					break
 				case "dsp-40":
-					store = VIDEO_STORE_VEVO
+					video.Stores[VIDEO_STORE_VEVO] = true
 					break
-			}
-			if store != VIDEO_STORE_NONE {
-				video.Stores = append(video.Stores, store)
 			}
 		})
 	})

--- a/videos.go
+++ b/videos.go
@@ -1,6 +1,8 @@
 package distrogo
 
 import (
+	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -48,6 +50,7 @@ func GetVideo(id string) (Video, error) {
 
 	var video Video
 	var err error
+	var redirected bool = false
 
 	video.ID = id
 	if strings.HasPrefix(id, "mv-") {
@@ -61,6 +64,10 @@ func GetVideo(id string) (Video, error) {
 	collector.OnError(func(r *colly.Response, e error) {
 		err = e
 	})
+	collector.RedirectHandler = func(r *http.Request, via []*http.Request) error {
+		redirected = true
+		return http.ErrUseLastResponse
+	}
 
 	collector.OnHTML("div.videoMetadataContainer", func(el *colly.HTMLElement) {
 		video.Title = strings.TrimSpace(el.DOM.Find("div[style*=\"line-height: 1.5\"]").Nodes[0].FirstChild.Data)
@@ -153,6 +160,10 @@ func GetVideo(id string) (Video, error) {
 	})
 
 	collector.Visit(url)
+
+	if redirected {
+		return video, errors.New("Video unavailable (redirected).")
+	}
 
 	if video.Type == VIDEO_TYPE_MINIVIDEO && len(video.Artist) == 0 {
 		// If we couldn't get the artist name for a mini-video from recommended videos,

--- a/videos.go
+++ b/videos.go
@@ -14,10 +14,19 @@ const (
 	VIDEO_TYPE_DISTROVID = iota
 )
 
+const (
+	VIDEO_STORE_NONE = iota
+	VIDEO_STORE_BOOMPLAY = iota
+	VIDEO_STORE_APPLEMUSIC = iota
+	VIDEO_STORE_TIDAL = iota
+	VIDEO_STORE_TIKTOKMUSIC = iota
+	VIDEO_STORE_VEVO = iota
+)
+
 type Video struct {
 	ID                 string
 	Type               int
-	Stores             []string
+	Stores             []int
 	Artist             string
 	Uploader           string
 	Title              string
@@ -95,8 +104,28 @@ func GetVideo(id string) (Video, error) {
 		video.Description = el.ChildText("pre")
 	})
 	collector.OnHTML("div.vDspContent", func(el *colly.HTMLElement) {
-		el.ForEach("img.store-icon", func(i int, storeEl *colly.HTMLElement) {
-			video.Stores = append(video.Stores, storeEl.Attr("title"))
+		el.ForEach("img.store-icon:not(.hidden)", func(i int, storeEl *colly.HTMLElement) {
+			var store int = VIDEO_STORE_NONE
+			switch storeEl.Attr("id") {
+				case "dsp-87":
+					store = VIDEO_STORE_BOOMPLAY
+					break
+				case "dsp-41":
+					store = VIDEO_STORE_APPLEMUSIC
+					break
+				case "dsp-42":
+					store = VIDEO_STORE_TIDAL
+					break
+				case "dsp-79":
+					store = VIDEO_STORE_TIKTOKMUSIC
+					break
+				case "dsp-40":
+					store = VIDEO_STORE_VEVO
+					break
+			}
+			if store != VIDEO_STORE_NONE {
+				video.Stores = append(video.Stores, store)
+			}
 		})
 	})
 	collector.OnHTML("div.dvMetadataSection", func(el *colly.HTMLElement) {

--- a/videos.go
+++ b/videos.go
@@ -100,9 +100,12 @@ func GetVideo(id string) (Video, error) {
 		})
 	})
 	collector.OnHTML("div.dvMetadataSection", func(el *colly.HTMLElement) {
-		video.ReleaseDateString = strings.TrimPrefix(el.ChildText("div"), "Release date: ")
+		// Trim "Release date:" without a space initially, so if there is no release date available,
+		// the string doesn't have "Release date:" as a value, making time.Parse() fail.
+		video.ReleaseDateString = strings.TrimPrefix(el.ChildText("div"), "Release date:")
+		if len(video.ReleaseDateString) > 0 {
+			video.ReleaseDateString = strings.TrimPrefix(video.ReleaseDateString, " ")
 
-		if (len(video.ReleaseDateString) > 0) {
 			releaseDate, parseErr := time.Parse("Jan _2, 2006", video.ReleaseDateString)
 			err = parseErr
 			video.ReleaseDate = releaseDate


### PR DESCRIPTION
Adds a custom API for DistroKid music videos. The [Colly](https://github.com/gocolly/colly) package is used for scraping data from video watch pages.

List of additions:

* Enumerators for video types (Vizy, Mini-video, DistroVid).
* Enumerators for video stores (Boomplay, Apple Music, Tidal, TikTok Music, Vevo).
* The `Video` structure.
* `GetVideo(id string)` and `GetVideos(ids []string)` functions.

The videos API doesn't require any authentication.